### PR TITLE
beacon--shine: use end-of-visual-line when calculating end

### DIFF
--- a/beacon.el
+++ b/beacon.el
@@ -308,13 +308,10 @@ Only returns `beacon-size' elements."
 (defun beacon--shine ()
   "Shine a beacon at point."
   ;; if there is enough space we go forward, else backward
-  ;; Available space is:
-  ;;    (last-column - current column) + (window-width - last-column-position)
   (let* ((colors (beacon--color-range))
-         (end (save-excursion (end-of-visual-line) (current-column)))
-         (available (+ (- end (current-column))
-                       (- (window-body-width)
-                          (mod end (window-body-width)))))
+         (available (1+ (/ (- (nth 2 (window-edges nil t t t))
+                              (car (window-absolute-pixel-position)))
+                           (window-font-width))))
          (forward (if (or (not beacon-can-go-backwards)
                           (> available beacon-size))
                       t

--- a/beacon.el
+++ b/beacon.el
@@ -311,12 +311,12 @@ Only returns `beacon-size' elements."
   ;; Available space is:
   ;;    (last-column - current column) + (window-width - last-column-position)
   (let* ((colors (beacon--color-range))
-         (end (save-excursion (end-of-line) (current-column)))
+         (end (save-excursion (end-of-visual-line) (current-column)))
          (available (+ (- end (current-column))
                        (- (window-body-width)
                           (mod end (window-body-width)))))
          (forward (if (or (not beacon-can-go-backwards)
-                       (> available beacon-size))
+                          (> available beacon-size))
                       t
                     nil)))
     (save-excursion


### PR DESCRIPTION
so the end of line column is correct when using visual-line-mode